### PR TITLE
fix on node

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 	"scripts": {
 		"build": "tsc -p tsconfig.json",
 		"bench": "pnpm run build && node --experimental-specifier-resolution=node ./benchmark/all.js",
-		"test": "bun run ./test/index.test.ts"
+		"test": "bun run ./test/index.test.ts",
+		"prepare": "\"$npm_execpath\" run build"
 	},
 	"keywords": [],
 	"author": "Kyza",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default as makeStringifier } from "./makeStringifier";
-export { default as makeSchema } from "./makeSchema";
+export { default as makeStringifier } from "./makeStringifier.js";
+export { default as makeSchema } from "./makeSchema.js";

--- a/src/makeArrayTemplate.ts
+++ b/src/makeArrayTemplate.ts
@@ -1,6 +1,6 @@
-import accessSubKey from "./accessSubKey";
-import makeValueString from "./makeValueString";
-import { ArrayType, ReplacerFunction } from "./types";
+import accessSubKey from "./accessSubKey.js";
+import makeValueString from "./makeValueString.js";
+import { ArrayType, ReplacerFunction } from "./types.js";
 
 export default function makeArrayTemplate(
 	schema: ArrayType,

--- a/src/makeObjectTemplate.ts
+++ b/src/makeObjectTemplate.ts
@@ -1,6 +1,6 @@
-import accessSubKey from "accessSubKey";
-import makeValueString from "makeValueString";
-import { ObjectType, ReplacerFunction } from "./types";
+import accessSubKey from "./accessSubKey.js";
+import makeValueString from "./makeValueString.js";
+import { ObjectType, ReplacerFunction } from "./types.js";
 
 export default function makeObjectTemplate(
 	schema: ObjectType,

--- a/src/makeSchema.ts
+++ b/src/makeSchema.ts
@@ -1,4 +1,4 @@
-import { Schema } from "./types";
+import { Schema } from "./types.js";
 
 // A way to make a schema from an unknown JSON object.
 export default function makeSchema(object: object): Schema {

--- a/src/makeStringifier.ts
+++ b/src/makeStringifier.ts
@@ -1,6 +1,6 @@
-import escapeString from "./escapeString";
-import makeValueString from "./makeValueString";
-import { ReplacerFunction, Schema } from "./types";
+import escapeString from "./escapeString.js";
+import makeValueString from "./makeValueString.js";
+import { ReplacerFunction, Schema } from "./types.js";
 
 export default function makeStringifier(
 	schema: Schema,

--- a/src/makeStructTemplate.ts
+++ b/src/makeStructTemplate.ts
@@ -1,7 +1,7 @@
-import accessSubKey from "./accessSubKey";
-import escapeString from "./escapeString";
-import makeValueString from "./makeValueString";
-import { ReplacerFunction, StructType } from "./types";
+import accessSubKey from "./accessSubKey.js";
+import escapeString from "./escapeString.js";
+import makeValueString from "./makeValueString.js";
+import { ReplacerFunction, StructType } from "./types.js";
 
 export default function makeStructTemplate(
 	type: StructType,

--- a/src/makeTemplate.ts
+++ b/src/makeTemplate.ts
@@ -1,8 +1,8 @@
-import makeArrayTemplate from "./makeArrayTemplate";
-import makeObjectTemplate from "./makeObjectTemplate";
-import makeStructTemplate from "./makeStructTemplate";
-import makeTupleTemplate from "./makeTupleTemplate";
-import { ReplacerFunction, Schema } from "./types";
+import makeArrayTemplate from "./makeArrayTemplate.js";
+import makeObjectTemplate from "./makeObjectTemplate.js";
+import makeStructTemplate from "./makeStructTemplate.js";
+import makeTupleTemplate from "./makeTupleTemplate.js";
+import { ReplacerFunction, Schema } from "./types.js";
 
 export default function makeTemplate(
 	schema: Schema,

--- a/src/makeTupleTemplate.ts
+++ b/src/makeTupleTemplate.ts
@@ -1,6 +1,6 @@
-import accessSubKey from "./accessSubKey";
-import makeValueString from "./makeValueString";
-import { ReplacerFunction, TupleType } from "./types";
+import accessSubKey from "./accessSubKey.js";
+import makeValueString from "./makeValueString.js";
+import { ReplacerFunction, TupleType } from "./types.js";
 
 export default function makeTupleTemplate(
 	schema: TupleType,

--- a/src/makeValueString.ts
+++ b/src/makeValueString.ts
@@ -1,8 +1,8 @@
-import makeArrayTemplate from "./makeArrayTemplate";
-import makeObjectTemplate from "./makeObjectTemplate";
-import makeStructTemplate from "./makeStructTemplate";
-import makeTupleTemplate from "./makeTupleTemplate";
-import { ReplacerFunction, Type } from "./types";
+import makeArrayTemplate from "./makeArrayTemplate.js";
+import makeObjectTemplate from "./makeObjectTemplate.js";
+import makeStructTemplate from "./makeStructTemplate.js";
+import makeTupleTemplate from "./makeTupleTemplate.js";
+import { ReplacerFunction, Type } from "./types.js";
 
 export default function makeValueString(
 	accessor: string,


### PR DESCRIPTION
At the moment, this package doesn't work with node (even with type module etc).

This fixes this with the following changes:
 - the `prepare` script runs the `build` script: this makes tsc run on install so you can import it right away
 - all relative imports without file extensions have been given file extensions as required to make them resolve
 - the two imports that imported relative files as if they were packages were changed to be correct (how on earth did vscode even resolve those?????????)